### PR TITLE
Attribution only in Editor

### DIFF
--- a/Runtime/Editor/AttributionHandler.cs
+++ b/Runtime/Editor/AttributionHandler.cs
@@ -4,8 +4,10 @@ using UnityEngine;
 using UnityEditor;
 using System.Threading.Tasks;
 
+#if UNITY_EDITOR
 namespace LootLocker.Admin
 {
+
     [ExecuteInEditMode]
     public class AttributionHandler : MonoBehaviour
     {
@@ -103,3 +105,4 @@ namespace LootLocker.Admin
         }
     }
 }
+#endif

--- a/Runtime/Editor/VSAttribution.cs
+++ b/Runtime/Editor/VSAttribution.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine.Analytics;
 
+#if UNITY_EDITOR
 namespace UnityEditor.VSAttribution
 {
 	public static class VSAttribution
@@ -66,3 +67,4 @@ namespace UnityEditor.VSAttribution
 		}
 	}
 }
+#endif


### PR DESCRIPTION
 - Adding preprocessor directives for attribution, should only be in Editor